### PR TITLE
Added functionality to download selected points as .csv

### DIFF
--- a/app/src/js/AstroVectorGrid.js
+++ b/app/src/js/AstroVectorGrid.js
@@ -183,6 +183,10 @@ export default L.AstroVectorGrid = L.VectorGrid.Protobuf.extend({
         }
       }
     }
+    // Don't send out an empty .csv
+    if (fullFeatures.length == 0) {
+      return;
+    }
     let csvContent = "data:text/csv;charset=utf-8,"
       + fullFeatures.map(e => e.join(",")).join("\n");
 

--- a/app/src/js/AstroVectorGrid.js
+++ b/app/src/js/AstroVectorGrid.js
@@ -16,7 +16,6 @@ import Protobuf from "./Leaflet.VectorGrid.bundled.min.js";
 export default L.AstroVectorGrid = L.VectorGrid.Protobuf.extend({
   options: {
     interactive: true,
-    selected: false,
     rendererFactory: L.canvas.tile,
     vectorTileLayerStyles: {
       points_test2: {

--- a/app/src/js/AstroVectorGrid.js
+++ b/app/src/js/AstroVectorGrid.js
@@ -159,7 +159,7 @@ export default L.AstroVectorGrid = L.VectorGrid.Protobuf.extend({
 
   /**
    * @function AstroVectorGrid.prototype.selectedToCSV
-   * @description Returns a list of selected features
+   * @description Download selected points to a .csv file.
    *
    */
   selectedToCSV: function(event) {

--- a/app/src/js/AstroVectorGrid.js
+++ b/app/src/js/AstroVectorGrid.js
@@ -56,13 +56,6 @@ export default L.AstroVectorGrid = L.VectorGrid.Protobuf.extend({
     });
     map.on(L.Draw.Event.CREATED, this.selectFeatures, this);
 
-    // somehow "this" is lost with nested binding of event handlers
-    let vectorGrid = this;
-
-    // Whenever a new poly is created, bind an event handler to it.
-    map.on("draw:created", function(e) {
-      e.layer.on("click", vectorGrid.selectedToCSV, vectorGrid)
-    });
     L.VectorGrid.Protobuf.prototype.onAdd.call(this, map);
   },
 
@@ -154,6 +147,7 @@ export default L.AstroVectorGrid = L.VectorGrid.Protobuf.extend({
     }
     this.changeSelectedStyle(highlightedFeatures);
     this._selectedFeatures=highlightedFeatures;
+    event.layer.on("click", this.selectedToCSV, this)
     console.log(highlightedFeatures);
   },
 


### PR DESCRIPTION
Added functionality to download selected points as .csv.

This functionality is currently bound to a "click" event on a polygon.  It is important to note that if no AstroVectorGrid layer was created, then no event listener is bound to a drawn polygon.

In other words, to download a .csv:
1. Load the vector data onto the map
2. Select the desired data by drawing a polygon
3. Click the polygon

Currently, the .csv only includes the point id, the data source / location of data, and the x / y coordinates.  The columns are not labeled.